### PR TITLE
Remove framework requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,7 @@ sequence tempo.
 
 ### Tools and Frameworks
 
-Here at Splice, our front-end app is a mix of Angular and Angular 2, and all new front-end code is written in TypeScript. We'd like you to complete this project using JavaScript or TypeScript and either Angular (1 or 2), React (along with your favorite state-management library), or Ember.
-
-If you *really* want to use a different framework, let's talk about it ahead of time.
-
-Build tools are up to you but the easier it is for us to run, the better.
-
+Feel free to use whatever framework you want or no framework at all.
 
 ### Useful Timing Info
 


### PR DESCRIPTION
I completed this exercise and I think the framework requirement makes it take more time than necessary and I think we can get a high enough signal if a candidate chooses not to use one. 

Some candidates may find a framework easier, particularly if they are highly familiar with one, but if a candidate chooses to complete the exercise with just DOM APIs, I think that will provide enough talking points to follow up on in the next stage of the interview process.

cc @buritica 